### PR TITLE
add h-card, h-entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,18 @@ organized roughly in order of age and breadth of implementation.</p>
   your site.</p>
  </dd>
 
+ <dt><a href="https://microformats.org/wiki/h-card">h-card</a></dt>
+ <dd>
+  <p>The h-card standard defines a way to markup a person or organization in HTML 
+	  with common properties like name, icon, and website.</p>
+ </dd>
+
+ <dt><a href="https://microformats.org/wiki/h-entry">h-entry</a></dt>
+ <dd>
+  <p>The h-entry standard defines a way to markup a post or page in HTML 
+	  with common properties such as name, content, permalink, author, date published and/or updated.</p>
+ </dd>
+
  <dt><a href="https://micropub.spec.indieweb.org/">Micropub</a></dt>
  <dd>
   <p>The Micropub Standard defines a protocol used to create, update and delete posts on one's


### PR DESCRIPTION
Per https://degruchy.org/blog/2020/08/20/the-indieweb-landscape/ point about microformats being necessary in practice to make webmentions work, adding h-entry and h-card explicitly right next to Webmention for easier discoverability.