### PR TITLE
Add authorship discovery to home page, update copyright to 2021

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,10 +120,16 @@ organized roughly in order of age and breadth of implementation.</p>
   feeds collected by a server.</p>
  </dd>
 
+ <dt><a href="https://indieweb.org/authorship-spec">Authorship Discovery</a></dt>
+ <dd>
+  <p>Authorship Discovery is an algorithm that specifies how to discover and determine the author
+   of a post.</p>
+ </dd>
+
 </dl>
 
 <footer>
- <p><small>Copyright © 2018-2020 
+ <p><small>Copyright © 2018-2021 
    <a href="https://github.com/indieweb/spec.indieweb.org/graphs/contributors">IndieWeb community contributors</a>.
    Modified by AJ Jordan from WHATWG (<a href="https://spec.whatwg.org">spec.whatwg.org</a>;
    see there for their copyright). 


### PR DESCRIPTION
In response to Issue #14, I have created a PR to list authorship discovery on the spec home page. I also updated the copyright from 2020 to 2021.